### PR TITLE
Add formatTimestamp utility function for human-readable time formatting

### DIFF
--- a/utils/formatTimestamp.ts
+++ b/utils/formatTimestamp.ts
@@ -1,0 +1,58 @@
+/**
+ * Formats a timestamp into a human-readable string.
+ * @param timestamp - Date object or timestamp number to format
+ * @returns Human-readable string representation of time difference (e.g. "2 hours ago")
+ * @throws {Error} If timestamp is invalid
+ */
+export function formatTimestamp(timestamp: Date | number): string {
+  try {
+    const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
+    if (isNaN(date.getTime())) {
+      throw new Error('Invalid date');
+    }
+
+    const now = new Date();
+    const diff = now.getTime() - date.getTime();
+
+    // Handle future dates
+    if (diff < 0) {
+      return 'in the future';
+    }
+
+    // Convert to seconds
+    const seconds = Math.floor(diff / 1000);
+
+    if (seconds < 30) {
+      return 'just now';
+    }
+
+    if (seconds < 60) {
+      return `${seconds} seconds ago`;
+    }
+
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) {
+      return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+    }
+
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) {
+      return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+    }
+
+    const days = Math.floor(hours / 24);
+    if (days < 30) {
+      return `${days} day${days === 1 ? '' : 's'} ago`;
+    }
+
+    const months = Math.floor(days / 30);
+    if (months < 12) {
+      return `${months} month${months === 1 ? '' : 's'} ago`;
+    }
+
+    const years = Math.floor(months / 12);
+    return `${years} year${years === 1 ? '' : 's'} ago`;
+  } catch (error) {
+    throw new Error('Invalid timestamp provided');
+  }
+}


### PR DESCRIPTION
This PR adds a new utility function `formatTimestamp` that converts timestamps into human-readable strings for Task Master.

### Features
- Handles both Date objects and timestamp numbers as input
- Returns relative time strings (e.g., "2 hours ago", "3 days ago", "just now")
- Includes comprehensive JSDoc documentation
- Handles edge cases:
  - Invalid dates (throws Error)
  - Future dates (returns "in the future")
  - Various time units (seconds, minutes, hours, days, months, years)
- Proper plural handling for time units
- Exported as a module for reuse

### Implementation Details
- Located in `/utils/formatTimestamp.ts`
- Written in TypeScript with proper type definitions
- Uses a granular approach for different time ranges
- Includes error handling with try-catch

### Example Usage
```typescript
formatTimestamp(new Date())  // "just now"
formatTimestamp(Date.now() - 7200000)  // "2 hours ago"
formatTimestamp(new Date('2023-01-01'))  // "X months ago"
```

### Testing Considerations
The function should be tested with:
- Different time ranges
- Both Date objects and timestamps
- Invalid inputs
- Edge cases (future dates, very old dates)