### PR TITLE
Add formatTimestamp utility function for human-readable time formatting

### DIFF
--- a/utils/formatTimestamp.ts
+++ b/utils/formatTimestamp.ts
@@ -1,0 +1,59 @@
+/**
+ * Formats a timestamp into a human-readable string (e.g. "2 hours ago")
+ * @param timestamp - Date object or timestamp number to format
+ * @returns Formatted string representing time elapsed
+ * @throws {Error} If timestamp is invalid
+ */
+export function formatTimestamp(timestamp: Date | number): string {
+  // Convert number to Date if needed
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
+  
+  // Validate date
+  if (isNaN(date.getTime())) {
+    throw new Error('Invalid timestamp provided');
+  }
+
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  
+  // Handle future dates
+  if (diffMs < 0) {
+    return 'in the future';
+  }
+
+  // Convert to seconds
+  const diffSec = Math.floor(diffMs / 1000);
+  
+  // Less than a minute
+  if (diffSec < 60) {
+    return 'just now';
+  }
+
+  // Minutes
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) {
+    return `${diffMin} ${diffMin === 1 ? 'minute' : 'minutes'} ago`;
+  }
+
+  // Hours
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 24) {
+    return `${diffHours} ${diffHours === 1 ? 'hour' : 'hours'} ago`;
+  }
+
+  // Days
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) {
+    return `${diffDays} ${diffDays === 1 ? 'day' : 'days'} ago`;
+  }
+
+  // Months
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths < 12) {
+    return `${diffMonths} ${diffMonths === 1 ? 'month' : 'months'} ago`;
+  }
+
+  // Years
+  const diffYears = Math.floor(diffMonths / 12);
+  return `${diffYears} ${diffYears === 1 ? 'year' : 'years'} ago`;
+}


### PR DESCRIPTION
This PR adds a new utility function `formatTimestamp` that converts timestamps into human-readable strings like "2 hours ago", "3 days ago", etc.

### Features
- Handles both Date objects and timestamp numbers as input
- Returns human-readable relative time strings
- Includes comprehensive JSDoc documentation
- Handles edge cases:
  - Invalid dates (throws Error)
  - Future dates (returns "in the future")
  - Various time units (minutes, hours, days, months, years)
  - Proper singular/plural forms

### Usage Example
```typescript
formatTimestamp(new Date()) // "just now"
formatTimestamp(Date.now() - 7200000) // "2 hours ago"
formatTimestamp(new Date('2023-01-01')) // "X months ago"
```

### Technical Details
- Exported as a standalone function in utils directory
- Written in TypeScript with proper type definitions
- Follows clean code principles with clear variable naming
- Includes error handling for robustness

### Testing
Please test with:
- Different time intervals
- Both Date objects and timestamp numbers
- Edge cases (invalid dates, future dates)
- Different time zones