### PR TITLE
Add time-report.js with time reporting functionality

### DIFF
--- a/time-report.js
+++ b/time-report.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+
+const timeData = {
+    utc: '2025-07-28 01:12:03',
+    newYork: '2025-07-27 21:12:03'
+};
+
+/**
+ * Returns the current time report from different timezones
+ * @returns {string} Formatted time report
+ */
+function getCurrentTimeReport() {
+    return `Current UTC time is ${timeData.utc}, and the time in America/New_York is ${timeData.newYork}`;
+}
+
+/**
+ * Formats a timestamp into a human-readable format
+ * @param {string} timestamp - The timestamp to format
+ * @returns {string} Formatted timestamp
+ */
+function formatTime(timestamp) {
+    try {
+        const date = new Date(timestamp);
+        return date.toLocaleString();
+    } catch (error) {
+        throw new Error(`Invalid timestamp format: ${error.message}`);
+    }
+}
+
+if (require.main === module) {
+    const report = getCurrentTimeReport();
+    console.log(report);
+    
+    try {
+        fs.writeFileSync('current-time.txt', report);
+        console.log('Time data written to current-time.txt');
+    } catch (error) {
+        console.error('Error writing to file:', error);
+    }
+}
+
+module.exports = {
+    getCurrentTimeReport,
+    formatTime
+};


### PR DESCRIPTION
This PR adds a new `time-report.js` file that implements time reporting functionality with the following features:

### Features
- Retrieves and stores current time data from time-mcp server for UTC and America/New_York timezones
- Exports `getCurrentTimeReport()` function to get formatted time information
- Exports `formatTime(timestamp)` utility function for human-readable timestamp formatting
- Includes comprehensive JSDoc documentation for all functions
- Implements CLI interface for direct script execution
- Writes time data to `current-time.txt` file

### Implementation Details
- Uses Node.js built-in `fs` module for file operations
- Implements proper error handling for timestamp formatting and file writing
- Follows module.exports pattern for function exports
- Includes conditional logic for CLI execution

### Testing
The implementation can be tested by:
1. Running the file directly: `node time-report.js`
2. Importing and using the exported functions in other modules
3. Checking the generated `current-time.txt` file
4. Testing the formatTime function with various timestamps

### Notes
- Time data is currently hardcoded but can be updated to fetch from time-mcp server in future iterations
- Error handling is implemented for both file operations and timestamp formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a tool to display and report current UTC and New York times.
  * Added functionality to save the current time report to a file.
  * Improved error handling for invalid time formats and file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->