### PR TITLE
Add script to write MCP tool output to file

### DIFF
--- a/mcp-output.txt
+++ b/mcp-output.txt
@@ -1,0 +1,1 @@
+Current UTC time is 2025-07-28 01:23:46, and the time in America/New_York is 2025-07-27 21:23:46.

--- a/write-mcp-output.sh
+++ b/write-mcp-output.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+OUTPUT_FILE="mcp-output.txt"
+
+echo "Current UTC time is 2025-07-28 01:23:46, and the time in America/New_York is 2025-07-27 21:23:46." > "$OUTPUT_FILE" 2>/dev/null
+
+if [ $? -eq 0 ]; then
+    echo "Successfully wrote MCP output to $OUTPUT_FILE"
+else
+    echo "Error: Failed to write to $OUTPUT_FILE" >&2
+    exit 1
+fi


### PR DESCRIPTION
This PR adds a new bash script that writes MCP tool output to a text file.

### Changes
- Created `write-mcp-output.sh` script that:
  - Writes a specific MCP output timestamp to `mcp-output.txt`
  - Includes error handling for file write operations
  - Displays success/error messages
  - Is executable as a standalone script
- Added `mcp-output.txt` with the sample output

### Testing
- Script can be tested by running:
```bash
./write-mcp-output.sh
```
Expected output:
```
Successfully wrote MCP output to mcp-output.txt
```

### Notes
- The script has executable permissions (755)
- Error handling redirects stderr to /dev/null for the write operation
- Script exits with status code 1 on failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a script to generate a file containing the current UTC time and local time in the America/New_York timezone.
  * The script provides clear success or error messages after attempting to write the file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->