### PR TITLE
Add mcp-output.txt with current UTC and America/New_York timestamps

### DIFF
--- a/mcp-output.txt
+++ b/mcp-output.txt
@@ -1,0 +1,1 @@
+Current UTC time is 2025-07-28 01:30:05, and the time in America/New_York is 2025-07-27 21:30:05.


### PR DESCRIPTION
This PR adds a new file `mcp-output.txt` containing the current timestamp in both UTC and America/New_York timezone formats.

Changes made:
- Created new file `mcp-output.txt`
- Added timestamp showing:
  - UTC: 2025-07-28 01:30:05
  - America/New_York: 2025-07-27 21:30:05

The file provides a clear representation of the time difference between UTC and Eastern Time zones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new file displaying the current UTC time and the corresponding local time for America/New_York.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->