### PR TITLE
Document MCP Integration Status: Tools Not Available at Agent Level

### DIFF
--- a/mcp-output.txt
+++ b/mcp-output.txt
@@ -1,0 +1,18 @@
+MCP integration gap: Tools connected at VibeKit level but not available to agent
+
+Available Tools:
+- Task
+- Bash
+- Glob
+- Grep
+- LS
+- exit_plan_mode
+- Read
+- Edit
+- MultiEdit
+- Write
+- NotebookRead
+- NotebookEdit
+- WebFetch
+- TodoWrite
+- WebSearch


### PR DESCRIPTION
This PR documents the current integration status between VibeKit MCP manager and agent tool access.

## Changes Made
- Created `mcp-output.txt` to document the MCP integration status
- Confirmed that MCP tools are not available in the agent's tool list
- Listed all currently available tools for reference

## Integration Status
The check reveals that while there may be MCP connectivity at the VibeKit level, the MCP tools are not accessible to the agent. This indicates a potential integration gap that needs to be addressed.

## Available Tools
The file lists 15 basic tools available to the agent, including file operations, task management, and web interaction capabilities, but notably missing MCP-specific tools.

## Next Steps
This documentation will help track the integration status and can be used as a reference point for implementing full MCP tool access at the agent level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a file outlining the current MCP integration gap and listing available tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->