### PR TITLE
Document MCP Integration Status: Tools Not Available at Agent Level

### DIFF
--- a/mcp-output.txt
+++ b/mcp-output.txt
@@ -1,0 +1,18 @@
+MCP integration gap: Tools connected at VibeKit level but not available to agent
+
+Available tools:
+- Task
+- Bash
+- Glob
+- Grep
+- LS
+- exit_plan_mode
+- Read
+- Edit
+- MultiEdit
+- Write
+- NotebookRead
+- NotebookEdit
+- WebFetch
+- TodoWrite
+- WebSearch


### PR DESCRIPTION
This PR documents the current integration status between VibeKit MCP manager and agent tool access.

### Changes Made
- Created `mcp-output.txt` to document MCP tools availability status
- Confirmed that MCP tools are not available at the agent level
- Listed all currently available tools for reference

### Integration Status
The check reveals that while there may be MCP connectivity at the VibeKit level, the MCP tools are not accessible to the agent. This indicates a potential integration gap that needs to be addressed.

### Available Tools List
The file includes a comprehensive list of currently available tools, which will help in:
1. Understanding current agent capabilities
2. Identifying missing MCP-specific tools
3. Planning necessary integration work

### Next Steps
This documentation will help the team in:
- Identifying the integration gap
- Planning necessary work to expose MCP tools to the agent level
- Ensuring proper tool availability for future automation tasks