### PR TITLE
Add timestamp formatting utility

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,15 @@
+/**
+ * Formats a timestamp into a human readable string
+ * @param {Date|number} timestamp - Date object or Unix timestamp
+ * @returns {string} Formatted date string
+ */
+export function formatTimestamp(timestamp) {
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
+  return date.toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric'
+  });
+}


### PR DESCRIPTION
This PR adds a new `utils.js` file with a `formatTimestamp` function that converts Date objects or Unix timestamps into human-readable strings.

## Features
- Supports both Date objects and Unix timestamps
- Returns formatted string with year, month, day, hour, and minute
- Includes comprehensive JSDoc documentation
- Properly exported as ES module

## Usage
```javascript
import { formatTimestamp } from './utils.js';

formatTimestamp(new Date()); // "December 2, 2025 at 3:45 PM"
formatTimestamp(1733158500000); // Unix timestamp
```